### PR TITLE
NOT LIKE operator filter implementation

### DIFF
--- a/force-app/main/default/classes/SOQL.cls
+++ b/force-app/main/default/classes/SOQL.cls
@@ -182,9 +182,13 @@ public virtual inherited sharing class SOQL implements Queryable {
         Filter greaterOrEqual(Object value); // >= :value
         Filter containsSome(List<String> values); // LIKE :values
         Filter contains(String value); // LIKE :'%' + value + '%'
+        Filter notContains(String value); //NOT field LIKE :'%' + value + '%'
         Filter endsWith(String value); // LIKE :'%' + value
+        Filter notEndsWith(String value); // NOT field LIKE :'%' + value
         Filter startsWith(String value); // LIKE :value + '%'
+        Filter notStartsWith(String value); // NOT field LIKE :value + '%'
         Filter contains(String prefix, String value, String suffix); // custom LIKE
+        Filter notContains(String prefix, String value, String suffix); // custom NOT field LIKE
         Filter isIn(Iterable<Object> iterable); // IN :inList or inSet
         Filter isIn(List<Object> inList); // IN :inList
         Filter isIn(InnerJoin joinQuery); // SOQL.InnerJoin
@@ -1043,6 +1047,7 @@ public virtual inherited sharing class SOQL implements Queryable {
         private String field;
         private String comperator;
         private Object value;
+        private String notLike;
         private DisplayType fieldType;
         private Boolean skipBinding = false;
 
@@ -1121,16 +1126,32 @@ public virtual inherited sharing class SOQL implements Queryable {
             return contains('%', formattedString(value), '%');
         }
 
+        public Filter notContains(String value) {
+            return notLike().contains(value);
+        }
+
         public Filter endsWith(String value) {
             return contains('%', formattedString(value), '');
+        }
+        
+        public Filter notEndsWith(String value) {
+            return notLike().endsWith(value);
         }
 
         public Filter startsWith(String value) {
             return contains('', formattedString(value), '%');
         }
 
+        public Filter notStartsWith(String value) {
+            return notLike().startsWith(value);
+        }
+
         public Filter contains(String prefix, String value, String suffix) {
             return set('LIKE', prefix + formattedString(value) + suffix);
+        }
+
+        public Filter notContains(String prefix, String value, String suffix) {
+            return notLike().contains(prefix, value, suffix);
         }
 
         private String formattedString(String value) {
@@ -1144,6 +1165,11 @@ public virtual inherited sharing class SOQL implements Queryable {
         public Filter isIn(InnerJoin joinQuery) {
             skipBinding = true;
             return set('IN', joinQuery);
+        }
+
+        public Filter notLike() {
+            this.notLike = 'NOT';
+            return this;
         }
 
         public Filter notIn(Iterable<Object> iterable) {
@@ -1196,13 +1222,19 @@ public virtual inherited sharing class SOQL implements Queryable {
             }
             return this;
         }
-
+        
         public override String toString() {
             if (skipBinding) {
-                return field + ' ' + comperator + ' ' + value;
+                return wrapWithNotOperator(field + ' ' + comperator + ' ' + value);
             }
-
-            return field + ' ' + comperator + ' :' + binder.bind(value);
+            
+            return wrapWithNotOperator(field + ' ' + comperator + ' :' + binder.bind(value));
+        }
+        
+        private String wrapWithNotOperator(String filterExpression) {
+            return String.isEmpty(notLike) 
+                ? filterExpression 
+                : String.format('({0} {1})', new List<String> { notLike, filterExpression });
         }
     }
 

--- a/force-app/main/default/classes/SOQL.cls
+++ b/force-app/main/default/classes/SOQL.cls
@@ -1047,7 +1047,7 @@ public virtual inherited sharing class SOQL implements Queryable {
         private String field;
         private String comperator;
         private Object value;
-        private String notLike;
+        private String wrapper = '{0}';
         private DisplayType fieldType;
         private Boolean skipBinding = false;
 
@@ -1167,8 +1167,8 @@ public virtual inherited sharing class SOQL implements Queryable {
             return set('IN', joinQuery);
         }
 
-        public Filter notLike() {
-            this.notLike = 'NOT';
+        private Filter notLike() {
+            this.wrapper = '(NOT {0})';
             return this;
         }
 
@@ -1225,16 +1225,10 @@ public virtual inherited sharing class SOQL implements Queryable {
         
         public override String toString() {
             if (skipBinding) {
-                return wrapWithNotOperator(field + ' ' + comperator + ' ' + value);
+                return String.format(wrapper, new List<String> { field + ' ' + comperator + ' ' + value });
             }
             
-            return wrapWithNotOperator(field + ' ' + comperator + ' :' + binder.bind(value));
-        }
-        
-        private String wrapWithNotOperator(String filterExpression) {
-            return String.isEmpty(notLike) 
-                ? filterExpression 
-                : String.format('({0} {1})', new List<String> { notLike, filterExpression });
+            return String.format(wrapper, new List<String> { field + ' ' + comperator + ' :' + binder.bind(value) });
         }
     }
 

--- a/force-app/main/default/classes/SOQL_Test.cls
+++ b/force-app/main/default/classes/SOQL_Test.cls
@@ -695,6 +695,20 @@ private class SOQL_Test {
     }
 
     @IsTest
+    static void notContains() {
+        // Test
+        SOQL builder = SOQL.of(Account.SObjectType)
+            .whereAre(SOQL.Filter.with(Account.Name).notContains('Test'));
+
+        // Verify
+        String soql = builder.toString();
+        Assert.areEqual('SELECT Id FROM Account WHERE (NOT Name LIKE :v1)', soql);
+
+        Map<String, Object> binding = builder.binding();
+        Assert.areEqual('%Test%', binding.get('v1'));
+    }
+
+    @IsTest
     static void containsValues() {
         // Setup
         List<String> names = new List<String>{ 'Acc', 'My' };
@@ -726,6 +740,20 @@ private class SOQL_Test {
     }
 
     @IsTest
+    static void notEndsWith() {
+        // Test
+        SOQL builder = SOQL.of(Account.SObjectType)
+            .whereAre(SOQL.Filter.with(Account.Name).notEndsWith('Test'));
+
+        // Verify
+        String soql = builder.toString();
+        Assert.areEqual('SELECT Id FROM Account WHERE (NOT Name LIKE :v1)', soql);
+
+        Map<String, Object> binding = builder.binding();
+        Assert.areEqual('%Test', binding.get('v1'));
+    }
+
+    @IsTest
     static void startsWith() {
         // Test
         SOQL builder = SOQL.of(Account.SObjectType)
@@ -734,6 +762,20 @@ private class SOQL_Test {
         // Verify
         String soql = builder.toString();
         Assert.areEqual('SELECT Id FROM Account WHERE Name LIKE :v1', soql);
+
+        Map<String, Object> binding = builder.binding();
+        Assert.areEqual('Test%', binding.get('v1'));
+    }
+    
+    @IsTest
+    static void notStartsWith() {
+        // Test
+        SOQL builder = SOQL.of(Account.SObjectType)
+            .whereAre(SOQL.Filter.with(Account.Name).notStartsWith('Test'));
+
+        // Verify
+        String soql = builder.toString();
+        Assert.areEqual('SELECT Id FROM Account WHERE (NOT Name LIKE :v1)', soql);
 
         Map<String, Object> binding = builder.binding();
         Assert.areEqual('Test%', binding.get('v1'));
@@ -748,6 +790,20 @@ private class SOQL_Test {
         // Verify
         String soql = builder.toString();
         Assert.areEqual('SELECT Id FROM Account WHERE Name LIKE :v1', soql);
+
+        Map<String, Object> binding = builder.binding();
+        Assert.areEqual('_Test%', binding.get('v1'));
+    }
+
+    @IsTest
+    static void customNotContains() {
+        // Test
+        SOQL builder = SOQL.of(Account.SObjectType)
+            .whereAre(SOQL.Filter.with(Account.Name).notContains('_', 'Test', '%'));
+
+        // Verify
+        String soql = builder.toString();
+        Assert.areEqual('SELECT Id FROM Account WHERE (NOT Name LIKE :v1)', soql);
 
         Map<String, Object> binding = builder.binding();
         Assert.areEqual('_Test%', binding.get('v1'));

--- a/website/docs/api/soql-filter.md
+++ b/website/docs/api/soql-filter.md
@@ -33,9 +33,13 @@ The following are methods for `Filter`.
 - [`greaterOrEqual(Object value)`](#greaterorequal)
 - [`containsSome(List<String> values)`](#containssome)
 - [`contains(String value)`](#contains)
+- [`notContains(String value)`](#notcontains)
 - [`endsWith(String value)`](#endswith)
+- [`notEndsWith(String value)`](#notendswith)
 - [`startsWith(String value)`](#startswith)
+- [`notStartsWith(String value)`](#notstartswith)
 - [`contains(String prefix, String value, String suffix)`](#contains)
+- [`notContains(String prefix, String value, String suffix)`](#notcontains)
 - [`isIn(Iterable<Object> iterable)`](#isin)
 - [`isIn(List<Object> inList)`](#isin)
 - [`isIn(InnerJoin joinQuery)`](#isin-join-query)
@@ -501,6 +505,34 @@ SOQL.of(Contact.SObjectType)
     .toList();
 ```
 
+### notcontains
+
+- `WHERE NOT Name LIKE '%My%'`
+
+**Signature**
+
+```apex
+Filter notContains(String value)
+Filter notContains(String prefix, String value, String suffix);
+```
+
+**Example**
+
+```sql
+SELECT Id
+FROM Account
+WHERE NOT Name LIKE '%My%'
+```
+```apex
+SOQL.of(Contact.SObjectType)
+    .whereAre(SOQL.Filter.name().notContains('My'))
+    .toList();
+
+SOQL.of(Contact.SObjectType)
+    .whereAre(SOQL.Filter.name().notContains('_', 'My', '%'))
+    .toList();
+```
+
 ### endsWith
 
 - `WHERE Name LIKE '%My'`
@@ -524,6 +556,29 @@ SOQL.of(Contact.SObjectType)
     .toList();
 ```
 
+### notEndsWith
+
+- `WHERE NOT Name LIKE '%My'`
+
+**Signature**
+
+```apex
+Filter notEndsWith(String value)
+```
+
+**Example**
+
+```sql
+SELECT Id
+FROM Account
+WHERE NOT Name LIKE '%My'
+```
+```apex
+SOQL.of(Contact.SObjectType)
+    .whereAre(SOQL.Filter.name().notEndsWith('My'))
+    .toList();
+```
+
 ### startsWith
 
 - `WHERE Name LIKE 'My%'`
@@ -544,6 +599,29 @@ WHERE Name = 'My%'
 ```apex
 SOQL.of(Contact.SObjectType)
     .whereAre(SOQL.Filter.name().startsWith('My'))
+    .toList();
+```
+
+### notStartsWith
+
+- `WHERE NOT Name LIKE 'My%'`
+
+**Signature**
+
+```apex
+Filter notStartsWith(String value)
+```
+
+**Example**
+
+```sql
+SELECT Id
+FROM Account
+WHERE NOT Name LIKE 'My%'
+```
+```apex
+SOQL.of(Contact.SObjectType)
+    .whereAre(SOQL.Filter.name().notStartsWith('My'))
     .toList();
 ```
 


### PR DESCRIPTION
`NOT LIKE` operator is not that popular capability of the Salesforce SOQL. It works the same way `LIKE` operator does. We can use `NOT LIKE` operator to extract those rows which do NOT have a particular substring in the filtered field.

The tricky part is the syntax (unfortunately I hadn't found this in the official documentation).
`NOT` operator needs to be added before the field that we're trying to filter and needs to be wrapped with the parentheses to properly work with the group of filters.

Examples:
`SELECT Id FROM Account WHERE Type = 'Customer' AND (NOT Name LIKE '%Ltd%') `