### PR TITLE
Make contributing to docs easier

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -40,6 +40,9 @@ const config = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           routeBasePath: '/',
+          editUrl: ({ docPath }) => {
+            return `https://holocron.so/github/pr/beyond-the-cloud-dev/soql-lib/main/editor/website/docs/${docPath}`
+          },
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
With this PR readers can suggest changes to the docs with an easy to use WYSIWYG markdown editor.

[This](https://holocron.so/github/pr/beyond-the-cloud-dev/soql-lib/main/editor) is how the editor looks like for this repo.

https://github.com/remorses/docusaurus-example/assets/31321188/43c8bc68-3668-4a25-bf1c-a70eceab7bcb