### PR TITLE
Implemented invalidateRecords() + Unit tests

### DIFF
--- a/force-app/main/default/classes/main/cached-soql/SOQLCache.cls
+++ b/force-app/main/default/classes/main/cached-soql/SOQLCache.cls
@@ -81,9 +81,12 @@ public virtual inherited sharing class SOQLCache implements Cacheable {
                     for (Integer i = 0; i < cacheItems.size(); i++) {
                         CacheItem cacheItem = cacheItems.get(i);
                         if (cacheItem.id == record.Id) {
-                            cache.remove(record.Id);
+                            cacheItems.remove(i);
+                            break;
                         }
                     }
+                    // put back updated cache items into cache
+                    cache.put(key, cacheItems);
                 }
             }
         }

--- a/force-app/main/default/classes/main/cached-soql/SOQLCache.cls
+++ b/force-app/main/default/classes/main/cached-soql/SOQLCache.cls
@@ -14,6 +14,8 @@
 **/
 @SuppressWarnings('PMD.ExcessivePublicCount, PMD.ExcessiveClassLength, PMD.CyclomaticComplexity, PMD.CognitiveComplexity, PMD.PropertyNamingConventions, PMD.FieldDeclarationsShouldBeAtStart, PMD.ApexDoc, PMD.ExcessiveParameterList')
 public virtual inherited sharing class SOQLCache implements Cacheable {
+    private static final String TEST_STR = 'Test'; // Cant be just TEST because then overrides standard Test class
+
     public interface Selector {
         Cacheable query();
     }
@@ -59,6 +61,32 @@ public virtual inherited sharing class SOQLCache implements Cacheable {
     @TestVisible
     private static void setMock(String mockId, SObject record) {
         mock.setMock(mockId, new List<SObject>{ record });
+    }
+
+    public static void invalidateRecords(List<SObject> records) {
+        List<CacheManager.Cacheable> caches = new List<CacheManager.Cacheable>{
+                CacheManager.SOQLOrgCache,
+                CacheManager.SOQLSessionCache,
+                CacheManager.ApexTransaction
+        };
+        for (CacheManager.Cacheable cache : caches) {
+            for (SObject record : records) {
+                SObjectType sObjectType = record.getSObjectType();
+                String key = sObjectType.toString();
+                if (Test.isRunningTest()) {
+                    key += TEST_STR;
+                }
+                if (cache.contains(key)) {
+                    List<CacheItem> cacheItems = (List<CacheItem>) cache.get(key);
+                    for (Integer i = 0; i < cacheItems.size(); i++) {
+                        CacheItem cacheItem = cacheItems.get(i);
+                        if (cacheItem.id == record.Id) {
+                            cache.remove(record.Id);
+                        }
+                    }
+                }
+            }
+        }
     }
 
     public static Cacheable of(SObjectType ofObject) {
@@ -258,7 +286,7 @@ public virtual inherited sharing class SOQLCache implements Cacheable {
         }
 
         private String key() {
-            return Test.isRunningTest() ? this.ofObject + 'Test' : this.ofObject;
+            return Test.isRunningTest() ? this.ofObject + TEST_STR : this.ofObject;
         }
     }
 

--- a/force-app/main/default/classes/main/cached-soql/SOQLCache_Test.cls
+++ b/force-app/main/default/classes/main/cached-soql/SOQLCache_Test.cls
@@ -559,6 +559,33 @@ private class SOQLCache_Test {
         Assert.isTrue(profile2.isSet('UserLicenseId'), 'The profile UserLicenseId should not be set.');
     }
 
+    @IsTest
+    static void recordsClearedFromCache() {
+        // Setup
+        Account testAccount = new Account(Name = 'Acme Corp');
+        insert testAccount;
+
+        Account cachedAccount = (Account) SOQLCache.of(Account.SObjectType)
+                .with(Account.Id, Account.Name)
+                .byId(testAccount.Id)
+                .cacheInOrgCache()
+                .toObject();
+
+        List<SOQLCache.CacheItem> cacheItems = (List<SOQLCache.CacheItem>) CacheManager.SOQLOrgCache.get('AccountTest');
+
+        //Verify initial setup
+        Assert.isTrue(CacheManager.SOQLOrgCache.contains('AccountTest'), 'Key should exist.');
+        Assert.isFalse(cacheItems.isEmpty(), 'Cache item should be present');
+
+        //Test
+        SOQLCache.invalidateRecords(new List<Account>{cachedAccount});
+
+        // Verify
+        Assert.isTrue(CacheManager.SOQLOrgCache.contains('AccountTest'), 'Key should still exist.');
+        cacheItems = (List<SOQLCache.CacheItem>) CacheManager.SOQLOrgCache.get('AccountTest');
+        Assert.isTrue(cacheItems.isEmpty(), 'Cache items should be empty');
+    }
+
     static User minimumAccessUser() {
         return new User(
             Alias = 'newUser',


### PR DESCRIPTION
Added static `invalidateRecords()` method in SOQLCache, please review.
Though it doesnt work as expected, Org Cache is always empty (I have a default partition named SOQL set as default) and I struggle to figure out why, need your help here @pgajek2
Probably I dont understand how the caching works in the lib, what I tried as testing is below:

Caching the account record:
```
Account cachedAccount = (Account) SOQLCache.of(Account.SObjectType)
        .with(Account.Id, Account.Name)
        .whereEqual(Account.Name, 'SOQL')
        
        .cacheInOrgCache()
        .cacheInSessionCache()
        .toObject();
System.debug(Limits.getQueries());
System.debug(cachedAccount);
```  
Result:
```
USER_DEBUG|[8]|DEBUG|0
USER_DEBUG|[9]|DEBUG|Account:{Name=SOQL, Id=001JX00000Z1waUYAR}
```

Cache debug:
```
System.debug(CacheManager.SOQLOrgCache.get('Account'));
System.debug(CacheManager.SOQLSessionCache.get('Account'));
```
Result:
```
DEBUG|null
DEBUG|(CacheItem:[cachedDate=2025-01-17 13:22:02, id=001JX00000Z1waUYAR, record=Account:{Name=SOQL, Id=001JX00000Z1waUYAR}])
```