### PR TITLE
Dynamic Query Improvements: aggregate function exceptions, Filter Gro…

### DIFF
--- a/force-app/main/default/classes/main/standard-soql/SOQL.cls
+++ b/force-app/main/default/classes/main/standard-soql/SOQL.cls
@@ -158,6 +158,7 @@ public virtual inherited sharing class SOQL implements Queryable {
         SubQuery with(SObjectField field1, SObjectField field2, SObjectField field3, SObjectField field4);
         SubQuery with(SObjectField field1, SObjectField field2, SObjectField field3, SObjectField field4, SObjectField field5);
         SubQuery with(Iterable<SObjectField> fields);
+        SubQuery with(String fields);
         SubQuery with(String relationshipName, Iterable<SObjectField> fields);
         SubQuery with(SubQuery subQuery);
         // WHERE
@@ -166,6 +167,7 @@ public virtual inherited sharing class SOQL implements Queryable {
         //ORDER BY
         SubQuery orderBy(SObjectField field);
         SubQuery orderBy(String relationshipName, SObjectField field);
+        SubQuery orderBy(String field, String direction);
         SubQuery sortDesc();
         SubQuery nullsLast();
         // LIMIT
@@ -181,7 +183,9 @@ public virtual inherited sharing class SOQL implements Queryable {
         // ADD CONDITION
         FilterGroup add(FilterGroup filterGroup);
         FilterGroup add(Filter filter);
+        FilterGroup addAll(List<Filter> filters);
         FilterGroup add(String dynamicCondition);
+        FilterGroup addAll(List<String> dynamicConditions);
         // ORDER
         FilterGroup anyConditionMatching();
         FilterGroup conditionLogic(String order);
@@ -1063,7 +1067,12 @@ public virtual inherited sharing class SOQL implements Queryable {
 
         private Boolean isAggregateFunction(String field) {
             // AVG(), COUNT(), MIN(), MAX(), SUM() or Field aliasing
-            return field.contains('(') && field.contains(')') || field.contains(' ');
+            // Exclude other SOQL Funcions ex. toLabel(), convertCurrency(), FORMAT()
+            Set<String> exceptionFunctions = new Set<String>{ 'toLabel', 'convertCurrency', 'FORMAT' };
+            Pattern exceptionFunctionsRegexPattern = Pattern.compile('(?i)\\b(' + String.join(new List<String>(exceptionFunctions), '|') + ')\\s*\\(');
+            Matcher exceptionFunctionsMatcher = exceptionFunctionsRegexPattern.matcher(field);
+
+            return field.contains('(') && field.contains(')') && !exceptionFunctionsMatcher.find() || field.contains(' ');
         }
 
         public void with(Iterable<SObjectField> fields) {
@@ -1173,6 +1182,11 @@ public virtual inherited sharing class SOQL implements Queryable {
             return this;
         }
 
+        public SubQuery with(String fields) {
+            builder.fields.with(fields);
+            return this;
+        }
+
         public SubQuery with(String relationshipName, Iterable<SObjectField> fields) {
             builder.fields.with(relationshipName, fields);
             return this;
@@ -1200,6 +1214,11 @@ public virtual inherited sharing class SOQL implements Queryable {
 
         public SubQuery orderBy(String relationshipName, SObjectField field) {
             builder.orderBys.newOrderBy().with(relationshipName, field);
+            return this;
+        }
+
+        public SubQuery orderBy(String field, String direction) {
+            builder.orderBys.newOrderBy().with(field).sortingOrder(direction);
             return this;
         }
 
@@ -1318,8 +1337,22 @@ public virtual inherited sharing class SOQL implements Queryable {
             return add(new FilterAdapter(filter));
         }
 
+        public FilterGroup addAll(List<Filter> filters) {
+            for (Filter filter: filters) {
+                add(filter);
+            }
+            return this;
+        }
+
         public FilterGroup add(String dynamicCondition) {
             return add(new StringConditionAdapter(dynamicCondition));
+        }
+
+        public FilterGroup addAll(List<String> dynamicConditions) {
+            for (String dynamicCondition: dynamicConditions) {
+                add(dynamicCondition);
+            }
+            return this;
         }
 
         public FilterGroup add(FilterClause condition) {

--- a/force-app/main/default/classes/main/standard-soql/SOQL_Test.cls
+++ b/force-app/main/default/classes/main/standard-soql/SOQL_Test.cls
@@ -510,6 +510,17 @@ private class SOQL_Test {
     }
 
     @IsTest
+    static void withStringFieldsAndToLabelFunction() {
+        // Test
+        String soql = SOQL.of(Case.SObjectType)
+            .with('Id, toLabel(Status), Subject')
+            .toString();
+
+        // Verify
+        Assert.areEqual('SELECT Id, toLabel(Status), Subject FROM Case', soql);
+    }
+
+    @IsTest
     static void withFieldAlias() {
         // Test
         String soql = SOQL.of(Account.SObjectType)
@@ -779,6 +790,21 @@ private class SOQL_Test {
 
         // Verify
         Assert.areEqual('SELECT Name , (SELECT Id, Name FROM Contacts ORDER BY Name DESC NULLS LAST) FROM Account', soql);
+    }
+
+    @IsTest
+    static void subQueryOrderByDynamic() {
+        // Test
+        String soql = SOQL.of(Account.SObjectType)
+            .with(Account.Name)
+            .with(SOQL.SubQuery.of('Contacts')
+                .with(Contact.Id, Contact.Name)
+                .orderBy('Name', 'ASC')
+                .nullsLast()
+            ).toString();
+
+        // Verify
+        Assert.areEqual('SELECT Name , (SELECT Id, Name FROM Contacts ORDER BY Name ASC NULLS LAST) FROM Account', soql);
     }
 
     @IsTest
@@ -1489,6 +1515,65 @@ private class SOQL_Test {
         Map<String, Object> binding = builder.binding();
         Assert.areEqual('Test', binding.get('v1'));
         Assert.areEqual('Krakow', binding.get('v2'));
+    }
+
+    @IsTest
+    static void dynamicFiltersListGroup() {
+        // Setup
+        SOQL.FilterGroup filterGroup = SOQL.FilterGroup;
+
+        filterGroup.addAll(new List<SOQL.Filter> {
+            SOQL.Filter.with(Account.Name).equal('Test'),
+            SOQL.Filter.with(Account.BillingCity).equal('Krakow')
+        });
+
+        // Test
+        SOQL builder = SOQL.of(Account.SObjectType)
+            .whereAre(filterGroup);
+
+        // Verify
+        String soql = builder.toString();
+        Assert.areEqual('SELECT Id FROM Account WHERE (Name = :v1 AND BillingCity = :v2)', soql);
+
+        Map<String, Object> binding = builder.binding();
+        Assert.areEqual('Test', binding.get('v1'));
+        Assert.areEqual('Krakow', binding.get('v2'));
+    }
+
+    @IsTest
+    static void dynamicStringFiltersGroup() {
+        // Setup
+        SOQL.FilterGroup filterGroup = SOQL.FilterGroup;
+
+        filterGroup.add('Name = \'Test\'');
+        filterGroup.add('BillingCity = \'Krakow\'');
+
+        // Test
+        SOQL builder = SOQL.of(Account.SObjectType)
+            .whereAre(filterGroup);
+
+        // Verify
+        String soql = builder.toString();
+        Assert.areEqual('SELECT Id FROM Account WHERE (Name = \'Test\' AND BillingCity = \'Krakow\')', soql);
+    }
+
+    @IsTest
+    static void dynamicStringFiltersListGroup() {
+        // Setup
+        SOQL.FilterGroup filterGroup = SOQL.FilterGroup;
+
+        filterGroup.addAll(new List<String> {
+            'Name = \'Test\'',
+            'BillingCity = \'Krakow\''
+        });
+
+        // Test
+        SOQL builder = SOQL.of(Account.SObjectType)
+            .whereAre(filterGroup);
+
+        // Verify
+        String soql = builder.toString();
+        Assert.areEqual('SELECT Id FROM Account WHERE (Name = \'Test\' AND BillingCity = \'Krakow\')', soql);
     }
 
     @IsTest


### PR DESCRIPTION
Dynamic Query Improvements: 

- aggregate function exceptions 
`isAggregateFunction` no longer treats special SOQL functions (e.g., `toLabel(FieldAPI)`) as aggregate functions.

- FilterGroup add method bulkification, 
`addAll` methods to add List of SOQL.Filters or dynamic List of String filters
 
- SubQuery set dynamic order
 orderBy(field, direction) method for SubQuery
 