### PR TITLE
Always ensure Id is added to list of fields so that mocks do not strip it away

### DIFF
--- a/force-app/main/default/classes/main/standard-soql/SOQL.cls
+++ b/force-app/main/default/classes/main/standard-soql/SOQL.cls
@@ -1154,10 +1154,6 @@ public virtual inherited sharing class SOQL implements Queryable {
     }
 
     private class PlainFields extends SelectFields {
-        private PlainFields() {
-            this.add('Id');
-        }
-        
         public void add(Iterable<SObjectField> fields) {
             for (SObjectField field : fields) {
                 this.add(field.toString());
@@ -2183,6 +2179,9 @@ public virtual inherited sharing class SOQL implements Queryable {
 
                 for (String field : requestedFields) {
                     filteredFields.put(field, originalFields.get(field) ?? null);
+                }
+                if(originalFields.containsKey('Id')) {
+                    filteredFields.put('Id', originalFields.get('Id'));
                 }
 
                 // JSON.serialize and JSON.deserialize are used to copy not writtable fields

--- a/force-app/main/default/classes/main/standard-soql/SOQL.cls
+++ b/force-app/main/default/classes/main/standard-soql/SOQL.cls
@@ -892,7 +892,6 @@ public virtual inherited sharing class SOQL implements Queryable {
     }
 
     public Map<Id, SObject> toMap() {
-        this.with('Id');
         return this.converter.transform(this.executor.toList()).toMap();
     }
 
@@ -1155,6 +1154,10 @@ public virtual inherited sharing class SOQL implements Queryable {
     }
 
     private class PlainFields extends SelectFields {
+        private PlainFields() {
+            this.add('Id');
+        }
+        
         public void add(Iterable<SObjectField> fields) {
             for (SObjectField field : fields) {
                 this.add(field.toString());


### PR DESCRIPTION
~This is not a good solution most likely. It does ensure Id is always added to the queries, but then this may cause a lot of breaking changes in existing tests that may be asserting the generated Query String - just like it does in SOQL_Test.~
updated with different solution

It would be better to ensure only mocks add this once the query had been generated (mocks don't really generate the query, right?). Like last commit added it to toMap(), but actually the same is a problem in all the options, e.g. toList, toObject.. only then the issue does not manifest inside SOQL but in clients:

The client code may be working with Id later and expecting it to exist, even though it wasn't explicitly added to the query fields. Non-mocking scenario that is the case, but mocks will not include the Id unless it was part of the query fields (except for the patch for maps). 

Previous version of SOQL Lib _always_ included the Id field provided it were added to the mock data objects. Now v5 will strip it away.