### PR TITLE
Prevent NullPointer errors when mocking toMap() queries

### DIFF
--- a/force-app/main/default/classes/main/standard-soql/SOQL.cls
+++ b/force-app/main/default/classes/main/standard-soql/SOQL.cls
@@ -2390,7 +2390,7 @@ public virtual inherited sharing class SOQL implements Queryable {
             Map<String, String> customValuePerCustomKey = new Map<String, String>();
 
             for (SObject record : this.recordsToTransform) {
-                customValuePerCustomKey.put(record.get(keyField).toString(), record.get(valueField).toString());
+                customValuePerCustomKey.put(record.get(keyField).toString(), record.get(valueField)?.toString());
             }
 
             return customValuePerCustomKey;


### PR DESCRIPTION
When toMap override of key/value (from specific field) was mocked and the mock SObject record provided did not have the field populated a NullPointer was thrown when getting the value and calling toString() on it. It would be more correct to ensure provided records contain the fields, but since in previous versions this was also not required it is essential to preserve this behaviour.