### PR TITLE
reduce number of query rows in `toIdsOf` & `toValuesOf` methods

### DIFF
--- a/force-app/main/default/classes/standard-soql/SOQL.cls
+++ b/force-app/main/default/classes/standard-soql/SOQL.cls
@@ -502,6 +502,10 @@ global virtual inherited sharing class SOQL implements Queryable {
 	}
 
 	global Queryable with(Iterable<String> fields) {
+		if (!fields.iterator().hasNext()) {
+			return this;
+		}
+
 		return this.with(String.join(fields, ','));
 	}
 

--- a/force-app/main/default/classes/standard-soql/SOQL_Test.cls
+++ b/force-app/main/default/classes/standard-soql/SOQL_Test.cls
@@ -547,6 +547,16 @@ private class SOQL_Test {
 	}
 
 	@IsTest
+	static void withEmptyListOfStringFields() {
+		// Test
+		String soql = SOQL.of(Account.SObjectType)
+			.with(new List<String>()).toString();
+
+		// Verify
+		Assert.areEqual('SELECT Id FROM Account', soql, 'The generated SOQL should match the expected one.');
+	}
+
+	@IsTest
 	static void withStringFields() {
 		// Test
 		String soql = SOQL.of(Account.SObjectType)


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

Reduce number of query rows when calling `toIdsOf` and `toValuesOf` methods.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Test improvements
- [ ] CI/CD improvements

## Changes Made

<!-- List the specific changes made in this PR -->

- Added `with('COUNT(Id)')` to the methods: `toIdsOf(String fieldToExtract)` and `toValuesOf(String fieldToExtract)`.

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes #
Closes https://github.com/beyond-the-cloud-dev/soql-lib/issues/262

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] All existing tests pass (`npm test`)
- [ ] Added new tests for new functionality
- [x] Tested in scratch org
- [x] Linting passes (`npm run lint`)
- [x] Code formatting is correct (`npm run prettier:verify`)

## Checklist

<!-- Mark completed items with an 'x' -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published