### PR TITLE
Skip ID generation for virtual sObjects without IDs and without key prefix

### DIFF
--- a/force-app/main/default/classes/standard-soql/SOQL.cls
+++ b/force-app/main/default/classes/standard-soql/SOQL.cls
@@ -2815,9 +2815,13 @@ public virtual inherited sharing class SOQL implements Queryable {
         }
 
         private void addIdToMockedRecords() {
-            // Id is always added to mirror standard SOQL behavior
+            // Id is added to mirror standard SOQL behavior
             SObjectType sObjectType = this.mockedRecords[0].getSObjectType();
             String sObjectPrefix = sObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).getKeyPrefix();
+
+            if (String.isBlank(sObjectPrefix)) {
+                return;
+            }
 
             for (SObject record : this.mockedRecords) {
                 record.put('Id', record?.Id ?? IdGenerator.get(sObjectPrefix));

--- a/force-app/main/default/classes/standard-soql/SOQL_Test.cls
+++ b/force-app/main/default/classes/standard-soql/SOQL_Test.cls
@@ -3017,6 +3017,21 @@ private class SOQL_Test {
     }
 
     @IsTest
+    static void mockingSingleRecordWhereSobjectPrefixIsNull() {
+        // Setup
+        Id recordId = SOQL.IdGenerator.get(Account.SObjectType);
+        UserRecordAccess testRecord = (UserRecordAccess) JSON.deserialize(JSON.serialize(new Map<String, Object>{ 'RecordId' => recordId }), UserRecordAccess.class);
+
+        // Test
+        SOQL.mock('mockingQuery').thenReturn(testRecord);
+        UserRecordAccess result = (UserRecordAccess) SOQL.of(UserRecordAccess.SObjectType).with(UserRecordAccess.RecordId).mockId('mockingQuery').toObject();
+
+        // Verify
+        Assert.areEqual(recordId, result.RecordId, 'The result record ID should be the same as the mocked record ID.');
+        Assert.isNull(result.Id, 'The result record Id should be null because it\'s not a real record and the SObject prefix is null.');
+    }
+
+    @IsTest
     static void mockingQueryException() {
         // Test
         SOQL.mock('mockingQuery').throwException();

--- a/package/main/default/classes/standard-soql/SOQL.cls
+++ b/package/main/default/classes/standard-soql/SOQL.cls
@@ -2657,9 +2657,13 @@ global virtual inherited sharing class SOQL implements Queryable {
         }
 
         private void addIdToMockedRecords() {
-            // Id is always added to mirror standard SOQL behavior
+            // Id is added to mirror standard SOQL behavior
             SObjectType sObjectType = this.mockedRecords[0].getSObjectType();
             String sObjectPrefix = sObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).getKeyPrefix();
+
+            if (String.isBlank(sObjectPrefix)) {
+                return;
+            }
 
             for (SObject record : this.mockedRecords) {
                 record.put('Id', record?.Id ?? IdGenerator.get(sObjectPrefix));

--- a/package/main/default/classes/standard-soql/SOQL_Full_Test.cls
+++ b/package/main/default/classes/standard-soql/SOQL_Full_Test.cls
@@ -3294,6 +3294,21 @@ private class SOQL_Full_Test {
     }
 
     @IsTest
+    static void mockingSingleRecordWhereSobjectPrefixIsNull() {
+        // Setup
+        Id recordId = SOQL.IdGenerator.get(Account.SObjectType);
+        UserRecordAccess testRecord = (UserRecordAccess) JSON.deserialize(JSON.serialize(new Map<String, Object>{ 'RecordId' => recordId }), UserRecordAccess.class);
+
+        // Test
+        SOQL.mock('mockingQuery').thenReturn(testRecord);
+        UserRecordAccess result = (UserRecordAccess) SOQL.of(UserRecordAccess.SObjectType).with(UserRecordAccess.RecordId).mockId('mockingQuery').toObject();
+
+        // Verify
+        Assert.areEqual(recordId, result.RecordId, 'The result record ID should be the same as the mocked record ID.');
+        Assert.isNull(result.Id, 'The result record Id should be null because it\'s not a real record and the SObject prefix is null.');
+    }
+
+    @IsTest
     static void mockingQueryException() {
         // Test
         SOQL.mock('mockingQuery').throwException();


### PR DESCRIPTION
## Description

Add null check for sObject key prefix before generating record IDs. Prevents IDs from being created for virtual records such as UserRecordAccess, which do not have persistent IDs or a valid prefix.

Without this check, mocking of such records fails with an exception:
```
System.StringException: Invalid id: null0000jfqTrzkY
Class.SOQL.RandomIdGenerator.get: line 3401, column 1
```

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Test improvements
- [ ] CI/CD improvements

## Changes Made

- Add null check for sObject key prefix before generating record IDs. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

