### PR TITLE
align subquery interface with querable for with(relationship__r..)

### DIFF
--- a/force-app/main/default/classes/standard-soql/SOQL.cls
+++ b/force-app/main/default/classes/standard-soql/SOQL.cls
@@ -217,6 +217,11 @@ public virtual inherited sharing class SOQL implements Queryable {
         SubQuery with(SObjectField field1, SObjectField field2, SObjectField field3, SObjectField field4, SObjectField field5);
         SubQuery with(Iterable<SObjectField> fields);
         SubQuery with(String fields);
+        SubQuery with(String relationshipName, SObjectField field);
+        SubQuery with(String relationshipName, SObjectField field1, SObjectField field2);
+        SubQuery with(String relationshipName, SObjectField field1, SObjectField field2, SObjectField field3);
+        SubQuery with(String relationshipName, SObjectField field1, SObjectField field2, SObjectField field3, SObjectField field4);
+        SubQuery with(String relationshipName, SObjectField field1, SObjectField field2, SObjectField field3, SObjectField field4, SObjectField field5);
         SubQuery with(String relationshipName, Iterable<SObjectField> fields);
         SubQuery with(SubQuery subQuery);
         SubQuery toLabel(SObjectField field);
@@ -1680,6 +1685,36 @@ public virtual inherited sharing class SOQL implements Queryable {
 
         public SubQuery with(String fields) {
             this.builder.fields.with(fields);
+            return this;
+        }
+
+        @NamespaceAccessible
+        public SubQuery with(String relationshipName, SObjectField field) {
+            this.builder.fields.relationshipFields.add(relationshipName, new List<SObjectField>{ field });
+            return this;
+        }
+
+        @NamespaceAccessible
+        public SubQuery with(String relationshipName, SObjectField field1, SObjectField field2) {
+            this.builder.fields.relationshipFields.add(relationshipName, new List<SObjectField>{ field1, field2 });
+            return this;
+        }
+
+        @NamespaceAccessible
+        public SubQuery with(String relationshipName, SObjectField field1, SObjectField field2, SObjectField field3) {
+            this.builder.fields.relationshipFields.add(relationshipName, new List<SObjectField>{ field1, field2, field3 });
+            return this;
+        }
+
+        @NamespaceAccessible
+        public SubQuery with(String relationshipName, SObjectField field1, SObjectField field2, SObjectField field3, SObjectField field4) {
+            this.builder.fields.relationshipFields.add(relationshipName, new List<SObjectField>{ field1, field2, field3, field4 });
+            return this;
+        }
+
+        @NamespaceAccessible
+        public SubQuery with(String relationshipName, SObjectField field1, SObjectField field2, SObjectField field3, SObjectField field4, SObjectField field5) {
+            this.builder.fields.relationshipFields.add(relationshipName, new List<SObjectField>{ field1, field2, field3, field4, field5 });
             return this;
         }
 

--- a/force-app/main/default/classes/standard-soql/SOQL.cls
+++ b/force-app/main/default/classes/standard-soql/SOQL.cls
@@ -1688,31 +1688,26 @@ public virtual inherited sharing class SOQL implements Queryable {
             return this;
         }
 
-        @NamespaceAccessible
         public SubQuery with(String relationshipName, SObjectField field) {
             this.builder.fields.relationshipFields.add(relationshipName, new List<SObjectField>{ field });
             return this;
         }
 
-        @NamespaceAccessible
         public SubQuery with(String relationshipName, SObjectField field1, SObjectField field2) {
             this.builder.fields.relationshipFields.add(relationshipName, new List<SObjectField>{ field1, field2 });
             return this;
         }
 
-        @NamespaceAccessible
         public SubQuery with(String relationshipName, SObjectField field1, SObjectField field2, SObjectField field3) {
             this.builder.fields.relationshipFields.add(relationshipName, new List<SObjectField>{ field1, field2, field3 });
             return this;
         }
 
-        @NamespaceAccessible
         public SubQuery with(String relationshipName, SObjectField field1, SObjectField field2, SObjectField field3, SObjectField field4) {
             this.builder.fields.relationshipFields.add(relationshipName, new List<SObjectField>{ field1, field2, field3, field4 });
             return this;
         }
 
-        @NamespaceAccessible
         public SubQuery with(String relationshipName, SObjectField field1, SObjectField field2, SObjectField field3, SObjectField field4, SObjectField field5) {
             this.builder.fields.relationshipFields.add(relationshipName, new List<SObjectField>{ field1, field2, field3, field4, field5 });
             return this;

--- a/website/docs/soql/api/soql-sub.md
+++ b/website/docs/soql/api/soql-sub.md
@@ -30,6 +30,11 @@ The following are methods for `SubQuery`.
 - [`with(SObjectField field1, SObjectField field2, SObjectField field3, SObjectField field4)`](#with-field1---field5)
 - [`with(SObjectField field1, SObjectField field2, SObjectField field3, SObjectField field4, SObjectField field5)`](#with-field1---field5)
 - [`with(List<SObjectField> fields)`](#with-fields)
+- [`with(String relationshipName, SObjectField field)`](#with-related-field1---field5)
+- [`with(String relationshipName, SObjectField field1, SObjectField field2)`](#with-related-field1---field5)
+- [`with(String relationshipName, SObjectField field1, SObjectField field2, SObjectField field3)`](#with-related-field1---field5)
+- [`with(String relationshipName, SObjectField field1, SObjectField field2, SObjectField field3, SObjectField field4)`](#with-related-field1---field5)
+- [`with(String relationshipName, SObjectField field1, SObjectField field2, SObjectField field3, SObjectField field4, SObjectField field5)`](#with-related-field1---field5)
 - [`with(String relationshipName, Iterable<SObjectField> fields)`](#with-related-fields)
 - [`with(String fields)`](#with-string-fields)
 
@@ -156,6 +161,42 @@ SOQL.of(Account.SObjectType)
             Contact.Title,
             Contact.Salutation
         })
+    )
+    .toList();
+```
+
+### with related field1 - field5
+
+Allows to add parent field to a query.
+
+**Signature**
+
+```apex title="Single Related Field Method"
+SubQuery with(String relationshipName, SObjectField field)
+```
+```apex title="Two Related Fields Method"
+SubQuery with(String relationshipName, SObjectField field1, SObjectField field2);
+```
+```apex title="Three Related Fields Method"
+SubQuery with(String relationshipName, SObjectField field1, SObjectField field2, SObjectField field3);
+```
+```apex title="Four Related Fields Method"
+SubQuery with(String relationshipName, SObjectField field1, SObjectField field2, SObjectField field3, SObjectField field4);
+```
+```apex title="Five Related Fields Method"
+SubQuery with(String relationshipName, SObjectField field1, SObjectField field2, SObjectField field3, SObjectField field4, SObjectField field5);
+```
+
+**Example**
+
+```sql title="SOQL Query"
+SELECT (SELECT CreatedBy.Id, CreatedBy.Name FROM Contacts)
+FROM Account
+```
+```apex title="SOQL Lib Related Fields"
+SOQL.of(Account.SObjectType)
+    .with(SOQL.SubQuery.of('Contacts')
+        .with('CreatedBy', User.Id, User.Name)
     )
     .toList();
 ```


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->
Update SubQuery interface to align with Queryable for adding relationship fields. 

Accept `.with('Relation__r', SobjectField)` 

It made sense to me that SubQuery and Queryable should match in this case.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Test improvements
- [ ] CI/CD improvements

## Changes Made

<!-- List the specific changes made in this PR -->

- Add additional `.with('relationship__c...` to SubQuery

## Related Issues

<!-- Link to related issues using #issue_number -->

N/A

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] All existing tests pass (`npm test`)
- [ ] Added new tests for new functionality
- [x] Tested in scratch org
- [x] Linting passes (`npm run lint`)
- [ ] Code formatting is correct (`npm run prettier:verify`)

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->

## Checklist

<!-- Mark completed items with an 'x' -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

<!-- Add any additional information that reviewers should know -->
